### PR TITLE
fixed typo in crontab section

### DIFF
--- a/04_Others/Linux_training/Day 2/02 Processes and Run Levels/README.md
+++ b/04_Others/Linux_training/Day 2/02 Processes and Run Levels/README.md
@@ -88,7 +88,7 @@ sudo service apache2 stop
 - crontab -l
 - crontab -e
 - crontab -r
-- sudo cronttab -u username -l
+- sudo crontab -u username -l
 
 ### Crontab format
 ```


### PR DESCRIPTION
"sudo cronttab -u username -l" on line 91 changed to "sudo crontab -u username -l"  = Typo in cronttab